### PR TITLE
Escape queue name in execs; set name and path on File['lpoptions'] to fix dependency from default_queue in init.pp

### DIFF
--- a/manifests/default_queue.pp
+++ b/manifests/default_queue.pp
@@ -8,10 +8,10 @@
 class cups::default_queue (
   String $queue,
 ) {
-
+  $queue_e = shellquote($queue)
   exec { "lpadmin-d-${queue}":
-    command => "lpadmin -E -d ${queue}",
-    unless  => "lpstat -d | grep -w ${queue}",
+    command => "lpadmin -E -d ${queue_e}",
+    unless  => "lpstat -d | grep -w ${queue_e}",
     path    => ['/usr/sbin/', '/usr/bin/', '/sbin/', '/bin/'],
     require => Cups_queue[$queue]
   }

--- a/manifests/papersize.pp
+++ b/manifests/papersize.pp
@@ -5,9 +5,9 @@
 class cups::papersize (
   String $papersize
 ) {
-
+  $papersize_e = shellquote($papersize)
   exec { "paperconfig -p ${papersize}":
-    unless => "cat /etc/papersize | grep -w ${papersize}",
+    unless => "cat /etc/papersize | grep -w ${papersize_e}",
     path   => ['/usr/sbin/', '/usr/bin/', '/sbin/', '/bin/'],
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,7 +26,8 @@ class cups::server (
       mode   => '0755',
     }
 
-    file { "${conf_directory}/lpoptions" :
+    file { 'lpoptions' :
+      path    => "${conf_directory}/lpoptions",
       ensure  => 'absent',
       require => File[$conf_directory],
     }


### PR DESCRIPTION
I had a queue name with an ampersand in it, and this made the exec angry due to the lack of shell escaping, so I've added this to the couple of exec calls in the manifests.

Also set the lpoptions file resource to use plain 'lpoptions' as the name and the path set explicitly, so that the require on default_queue in init.pp works as expected (and isn't dependent on the file path).