### PR TITLE
Fix softtab

### DIFF
--- a/examples/minimal_class.pp
+++ b/examples/minimal_class.pp
@@ -21,8 +21,8 @@ cups_queue { 'Warehouse':
 include '::cups'
 
 cups_queue { 'MinimalClass':
-   ensure  => 'class',
-   members => ['Office', 'Warehouse']
+  ensure  => 'class',
+  members => ['Office', 'Warehouse']
 }
 
 # which will autorequire its `members` to ensure correct order of installation.


### PR DESCRIPTION
Fix softtab issue with puppet_lint

_Pull Request template_.

This Pull Request fixes/adds ... (about 2 sentences)
This removes 1 space from two lines. I was getting puppet-lint errors:
+ puppet-lint --log-format %{path}:%{line}:%{check}:%{KIND}:%{message} ./modules/cups/examples/minimal_class.pp
./modules/cups/examples/minimal_class.pp:24:2sp_soft_tabs:ERROR:two-space soft tabs not used
./modules/cups/examples/minimal_class.pp:25:2sp_soft_tabs:ERROR:two-space soft tabs not used

This is what I added/changed/removed and why I did ... (help the maintainer understand your PR)
removed 1 space from 2 lines

Related issue: (Your issue number goes here)
None

Legal statement:

By committing to this project I transfer the full copyright for my contributions
to the current project maintainer as per the project's LICENSE file.
