### PR TITLE
added server admin parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@
 #
 class cups (
   Optional[String]               $default_queue          = undef,
+  Optional[String]               $server_admin           = undef,
   Variant[String, Array[String]] $listen                 = ['localhost:631', '/var/run/cups/cups.sock'],
   String                         $package_ensure         = 'present',
   Boolean                        $package_manage         = true,

--- a/templates/cupsd.conf.erb
+++ b/templates/cupsd.conf.erb
@@ -6,6 +6,7 @@ MaxLogSize 0
 <%=    "Listen #{l}" %>
 <%   end -%>
 <% end -%>
+<% if @server_admin -%>ServerAdmin <%= "#{@server_admin}\r\n" %><% end -%>
 Browsing Off
 BrowseLocalProtocols dnssd
 DefaultAuthType Basic


### PR DESCRIPTION
_Pull Request template_.

This Pull Request add the ServerAdmin parameter to cupsd.conf, which was missing.

ServerAdmin email-address
    Specifies the email address of the server administrator. The default value is "root@ServerName". 

Related issue: no issue

Legal statement:

By committing to this project I transfer the full copyright for my contributions
to the current project maintainer as per the project's LICENSE file.
