### PR TITLE
added server_alias param

### DIFF
--- a/README.md.erb
+++ b/README.md.erb
@@ -479,6 +479,11 @@ Installs, configures, and manages the CUPS service.
 
 ##### Attributes
 
+* `server_alias`: Specifies an alternate name that the server is known by.
+  The special name "*" allows any name to be used.
+  Accepts (an array of) strings or a string.
+  Defaults to undef.
+
 * `default_queue`: The name of the default destination for all print jobs.
   Requires the catalog to contain a `cups_queue` resource with the same name.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@
 #     require => Package['hplip']
 #   }
 #
+# @param server_alias Specifies an alternate name that the server is known by. The special name "*" allows any name to be used.
 # @param default_queue The name of the default destination for all print jobs.
 #   Requires the catalog to contain a `cups_queue` resource with the same name.
 # @param listen Which addresses to the CUPS daemon should listen to.
@@ -44,19 +45,20 @@
 # @param web_interface Boolean value to enable or disable the server's web interface.
 #
 class cups (
-  Optional[String]               $default_queue          = undef,
-  Variant[String, Array[String]] $listen                 = ['localhost:631', '/var/run/cups/cups.sock'],
-  String                         $package_ensure         = 'present',
-  Boolean                        $package_manage         = true,
-  Variant[String, Array[String]] $package_names          = $::cups::params::package_names,
-  Optional[String]               $papersize              = undef,
-  Boolean                        $purge_unmanaged_queues = false,
-  Optional[Hash]                 $resources              = undef,
-  Boolean                        $service_enable         = true,
-  String                         $service_ensure         = 'running',
-  Boolean                        $service_manage         = true,
-  Variant[String, Array[String]] $service_names          = 'cups',
-  Optional[Boolean]              $web_interface          = undef,
+  Optional[Variant[String, Array[String]]] $server_alias           = undef,
+  Optional[String]                         $default_queue          = undef,
+  Variant[String, Array[String]]           $listen                 = ['localhost:631', '/var/run/cups/cups.sock'],
+  String                                   $package_ensure         = 'present',
+  Boolean                                  $package_manage         = true,
+  Variant[String, Array[String]]           $package_names          = $::cups::params::package_names,
+  Optional[String]                         $papersize              = undef,
+  Boolean                                  $purge_unmanaged_queues = false,
+  Optional[Hash]                           $resources              = undef,
+  Boolean                                  $service_enable         = true,
+  String                                   $service_ensure         = 'running',
+  Boolean                                  $service_manage         = true,
+  Variant[String, Array[String]]           $service_names          = 'cups',
+  Optional[Boolean]                        $web_interface          = undef,
 ) inherits cups::params {
 
   contain cups::packages

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'cups' do
 
     let(:undefs) do
       %i[
+        server_alias
         default_queue
         papersize
         resources
@@ -54,6 +55,26 @@ RSpec.describe 'cups' do
   end
 
   context 'with attribute' do
+    describe 'server_alias' do
+      let(:facts) { any_supported_os }
+
+      context 'when set to undef' do
+        it { is_expected.to_not contain_exec('cups::server_alias') }
+      end
+
+      context "when set to '*'" do
+        let(:params) { { server_alias: '*' } }
+
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: /^ServerAlias \*$/) }
+      end
+
+      context "when set to ['foo', 'foo.bar']" do
+        let(:params) { { listen: ['foo', 'foo.bar'] } }
+
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: /^ServerAlias foo foo.bar$/) }
+      end
+    end
+
     describe 'default_queue' do
       let(:facts) { any_supported_os }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'cups' do
       end
 
       context "when set to ['foo', 'foo.bar']" do
-        let(:params) { { listen: ['foo', 'foo.bar'] } }
+        let(:params) { { server_alias: ['foo', 'foo.bar'] } }
 
         it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: /^ServerAlias foo foo.bar$/) }
       end

--- a/templates/cupsd.conf.erb
+++ b/templates/cupsd.conf.erb
@@ -1,3 +1,8 @@
+<% if @server_alias.kind_of? Array -%>
+ServerAlias <% @server_aliases = [] %><% @server_alias.sort.each {| value | @server_aliases.insert(-1, "#{value}") } %><%= @server_aliases.join(" ") %>
+<% elsif @server_alias.kind_of? String -%>
+ServerAlias <%= @server_alias %>
+<% end -%>
 LogLevel warn
 PageLogFormat
 MaxLogSize 0


### PR DESCRIPTION
_Pull Request template_.

This Pull Request fixes/adds ... (about 2 sentences)

Adds the server_alias param for HA environments (LB). To prevent: E [17/Sep/2018:14:11:43 +0200] [Client 15] Request from "10.x.x.x" using invalid Host: field "foo.bar" 

Legal statement:

By committing to this project I transfer the full copyright for my contributions
to the current project maintainer as per the project's LICENSE file.
