### PR TITLE
Silence queue enumeration "normal" errors

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -543,7 +543,9 @@ Installs, configures, and manages the CUPS service.
 * `papersize`: Sets the system's default `/etc/papersize`. See `man papersize` for supported values.
 
 * `purge_unmanaged_queues`: Setting `true` will remove all queues from the node
-  which do not match a `cups_queue` resource in the current catalog. Defaults to `false`.
+  which do not match a `cups_queue` resource in the current catalog. Silently
+  ignored if the Cups server is not reachable when Puppet starts. Defaults to
+  `false`.
 
 * `resources`: This attribute is intended for use with Hiera or any other ENC (see the [example above](#using-hiera)).
 

--- a/README.md.erb
+++ b/README.md.erb
@@ -545,7 +545,9 @@ Installs, configures, and manages the CUPS service.
 * `papersize`: Sets the system's default `/etc/papersize`. See `man papersize` for supported values.
 
 * `purge_unmanaged_queues`: Setting `true` will remove all queues from the node
-  which do not match a `cups_queue` resource in the current catalog. Defaults to `false`.
+  which do not match a `cups_queue` resource in the current catalog. Silently
+  ignored if the Cups server is not reachable when Puppet starts. Defaults to
+  `false`.
 
 * `resources`: This attribute is intended for use with Hiera or any other ENC (see the [example above](#using-hiera)).
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,8 @@
 # @param page_log_format Sets the `PageLogFormat` directive of the CUPS server.
 # @param papersize Sets the system's default `/etc/papersize`. See `man papersize` for supported values.
 # @param purge_unmanaged_queues Setting `true` will remove all queues from the node
-#   which do not match a `cups_queue` resource in the current catalog.
+#   which do not match a `cups_queue` resource in the current catalog. Silently
+#   ignored if the Cups server is not reachable when Puppet starts.
 # @param resources This attribute is intended for use with Hiera or any other ENC.
 # @param server_alias Sets the `ServerAlias` directive of the CUPS server.
 # @param server_name Sets the `ServerName` directive of the CUPS server.

--- a/spec/acceptance/classes/cups_purge_unmanaged_queues_spec.rb
+++ b/spec/acceptance/classes/cups_purge_unmanaged_queues_spec.rb
@@ -14,4 +14,19 @@ RSpec.describe 'Including class "cups" with purge_unmanaged_queues' do
       end
     end
   end
+
+  context 'when the Cups service is running' do
+    before(:all) do
+      ensure_cups_is_running
+      purge_all_queues
+      add_printers('Office')
+    end
+
+    let(:manifest) { 'class { "cups": purge_unmanaged_queues => true }' }
+
+    it 'purges unmanaged queues' do
+      apply_manifest(manifest, expect_changes: true)
+      shell('lpstat -p Office', acceptable_exit_codes: [1])
+    end
+  end
 end

--- a/spec/acceptance/classes/cups_purge_unmanaged_queues_spec.rb
+++ b/spec/acceptance/classes/cups_purge_unmanaged_queues_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+RSpec.describe 'Including class "cups" with purge_unmanaged_queues' do
+  context 'when the Cups service is not running' do
+    before(:all) do
+      apply_manifest('class { "cups": service_ensure => "stopped" }', catch_failures: true)
+    end
+
+    it 'does not produce errors' do
+      apply_manifest('class { "cups": purge_unmanaged_queues => true }', catch_failures: true) do
+        assert_not_match(/ipptool: Unable to connect to/, stderr)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request silences ipptool errors when the module tries to enumerate queues from a stopped CUPS service. See #251 for more info.

This is what I added/changed/removed and why I did it ... 

1. I caught and redirected to the debug log the `PuppetX::Cups::Ipp::QueryError` when trying to enumerate classes and printers. Querying CUPS at this point cannot be guaranteed to succeed, but generates big noisy "normal" errors.
1. I updated the documentation accordingly.
1. I added an acceptance test for it. You can reproduce the issue easily by checking out the first commit.

Legal statement:

By committing to this project I transfer the full copyright for my contributions
to the current project maintainer as per the project's LICENSE file.
