### PR TITLE
Upgrade rubocop-rspec to version 1.39.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,6 @@ group :metatools do
   gem 'overcommit', '0.52.1'
   gem 'rubocop', '0.80.1'
   gem 'rubocop-performance', '1.5.2'
-  gem 'rubocop-rspec', '1.38.1'
+  gem 'rubocop-rspec', '1.39.0'
   gem 'travis', '1.8.11'
 end


### PR DESCRIPTION





Here is everything you need to know about this upgrade. Please take a good look at what changed and the test results before merging this pull request.

### What changed?

#### ✳️ rubocop-rspec (1.38.1 → 1.39.0) · [Repo](https://github.com/rubocop-hq/rubocop-rspec) · [Changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md)


<details>
<summary>Release Notes</summary>
<h4><a href="https://github.com/rubocop-hq/rubocop-rspec/releases/tag/v1.39.0">1.39.0</a></h4>

<blockquote><ul>
<li>Fix <code>RSpec/FilePath</code> detection when absolute path includes test subject. (<a href="https://bounce.depfu.com/github.com/eitoball">@eitoball</a>)</li>
<li>Add new <code>Capybara/VisibilityMatcher</code> cop. (<a href="https://bounce.depfu.com/github.com/aried3r">@aried3r</a>)</li>
<li>Ignore String constants by <code>RSpec/Describe</code>. (<a href="https://bounce.depfu.com/github.com/AlexWayfer">@AlexWayfer</a>)</li>
<li>Drop support for Ruby 2.3. (<a href="https://bounce.depfu.com/github.com/bquorning">@bquorning</a>)</li>
<li>Fix multiple cops to detect <code>let</code> with proc argument. (<a href="https://bounce.depfu.com/github.com/tejasbubane">@tejasbubane</a>)</li>
<li>Add autocorrect support for <code>RSpec/ScatteredLet</code>. (<a href="https://bounce.depfu.com/github.com/Darhazer">@Darhazer</a>)</li>
<li>Add new <code>RSpec/EmptyHook</code> cop. (<a href="https://bounce.depfu.com/github.com/tejasbubane">@tejasbubane</a>)</li>
</ul></blockquote>
<p><em>Does any of this look wrong? <a href="https://depfu.com/packages/rubygem/rubocop-rspec/feedback">Please let us know.</a></em></p>
</details>

<details>
<summary>Commits</summary>
<p><a href="https://github.com/rubocop-hq/rubocop-rspec/compare/d6f18f53092ebb6e2bcc9910834732e8c83fead1...f1956aef501a835165d32ab9ab2552d25c7020b5">See the full diff on Github</a>. The new version differs by 27 commits:</p>
<ul>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/f1956aef501a835165d32ab9ab2552d25c7020b5"><code>Merge pull request #906 from rubocop-hq/release</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/5d2d3f012143e920aed980bd818c61917e138dd4"><code>Bump version to v1.39.0</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/a0dadd65b49de17dff12be3011eded439fdd3069"><code>Merge pull request #897 from tejasbubane/empty-hooks-cop</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/184cba78e85e36a07f60d815a649a43d9129340e"><code>Add new `RSpec/EmptyHook` cop</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/0f7721ed39c2276a8f8d7a796213b19ed6bf6b6a"><code>Merge pull request #903 from rubocop-hq/scattered-let-autocorrect</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/9941338ccbdb945e04f7d6c5031ce09e64f25f0a"><code>Implement auto-correct for ScatteredLet cop</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/7615d62a4bc8baca7e31a2300a46ecbe3381a4cb"><code>Extract helper class for moving nodes arround</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/52a7fe13da7cfdf223dfb20bda97e057200795bf"><code>Merge pull request #904 from tejasbubane/fix-771</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/7e046a0ac79f1f82b77687e073c51b98c71460ed"><code>Fix multiple cops to detect `let` with proc argument</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/b5c18e13774bbb891dc48fbc2093998506c91e50"><code>Merge pull request #899 from ngoral/replace_should_style_example_for_named_subject</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/ff6b291101e490f14988913c1252064b3121d5b2"><code>Replace `should`-example with `expect`-example</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/03ce0a73ec5045543bdb4769807b80065b26df7d"><code>Merge pull request #900 from rubocop-hq/ci-matrix</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/5ee222c40ea18964f524c3d9f183b98d600b37b7"><code>Use CircleCI matrix feature</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/cd6bc333af1fe6881fcd20d8a96e1647b33a2b08"><code>Merge pull request #901 from rubocop-hq/drop-support-for-ruby-2.3</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/3038e0faaed2cc9e28a4acfdd2f922892d4f88e3"><code>Drop support for Ruby 2.3</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/dff8957b9f38b041207afe79b93042822cc0a877"><code>Merge pull request #891 from AlexWayfer/disable_RSpec/DescribeClass_for_string_constants</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/21610c0ba903fd7d67aa17e4de2d69ea31472ef8"><code>Ignore String constants by `RSpec/Describe`</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/3a2088f79737e2e8e0e21482783f7d61411bf021"><code>Merge pull request #890 from koic/fix_offenses_using_rubocop_0_81</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/478ab25a1d07af02bed6e4cc1c7c385cc74534e5"><code>Fix an offenses when using RuboCop 0.81.0</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/8c6af61cc0c5bc131c068b43c7611aa5e2140fa4"><code>Merge pull request #886 from aried3r/ar/add_capybara_visibility_cop</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/7aa334090da3f5cd73183dbc33dfb9568af74385"><code>Add Capybara/VisibilityMatcher cop</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/84cca3959879a1bea1d2ff7b9f7f07d216ba39e9"><code>Merge pull request #869 from eitoball/use-relative-path-for-file_path-cop</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/7970b192bf55992b8d29f60d52a14ac32fcf5678"><code>Merge pull request #883 from yujideveloper/fix/old-cop-option</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/9aed15e76892c82ed70b96f81cf0416764056748"><code>Remove already removed `AggregateFailuresByDefault` from default.yml</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/811ae08ea3a60453e18a8bcb9dfaefafd848f779"><code>Use relative path to match with glob</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/94d8084d91b274f26355184366be312e6751ff07"><code>Merge pull request #881 from rubocop-hq/fix-dstr-in-example-description</code></a></li>
<li><a href="https://github.com/rubocop-hq/rubocop-rspec/commit/be1dd98d6f08997c2d2c90da978b556c5926c0c4"><code>Merge pull request #878 from rubocop-hq/remove-one</code></a></li>
</ul>
</details>






---
![Depfu Status](https://depfu.com/badges/b664de4d78caad461da4a66da7c9efeb/stats.svg)

[Depfu](https://depfu.com) will automatically keep this PR conflict-free, as long as you don't add any commits to this branch yourself. You can also trigger a rebase manually by commenting with `@depfu rebase`.

<details><summary>All Depfu comment commands</summary>
<blockquote><dl>
<dt>@​depfu rebase</dt><dd>Rebases against your default branch and redoes this update</dd>
<dt>@​depfu recreate</dt><dd>Recreates this PR, overwriting any edits that you've made to it</dd>
<dt>@​depfu merge</dt><dd>Merges this PR once your tests are passing and conflicts are resolved</dd>
<dt>@​depfu close</dt><dd>Closes this PR and deletes the branch</dd>
<dt>@​depfu reopen</dt><dd>Restores the branch and reopens this PR (if it's closed)</dd>
<dt>@​depfu pause</dt><dd>Ignores all future updates for this dependency and closes this PR</dd>
<dt>@​depfu pause [minor|major]</dt><dd>Ignores all future minor/major updates for this dependency and closes this PR</dd>
<dt>@​depfu resume</dt><dd>Future versions of this dependency will create PRs again (leaves this PR as is)</dd>
</dl></blockquote>
</details>

