### PR TITLE
Allow for customization of policies

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -542,6 +542,46 @@ Installs, configures, and manages the CUPS service.
 
 * `papersize`: Sets the system's default `/etc/papersize`. See `man papersize` for supported values.
 
+* `policies`: Sets the printing policies (`default` and `authenticated`) for CUPS. By default,
+  it enables the default CUPS settings.  You can override those settings by setting all the options
+  you want set in a policy or setting all the directives in one of the limits under the policy.
+  You can, of course, also add more policies and other limits under the default policies as needed.
+
+```puppet
+  class { '::cups':
+    policies => {
+      'default' => {
+        'options' => [
+          'JobPrivateAccess default',
+          'JobPrivateValues default',
+          'SubscriptionPrivateAccess default',
+        ],
+        'limits' => {
+          'Create-Job Print-Job Print-URI Validate-Job' => [
+            'Require user @OWNER @SYSTEM',
+            'Order deny,allow',
+          ],
+        },
+      }
+    }
+  }
+```
+
+You can also do the same using hiera:
+
+```yaml
+cups::policies:
+  default:
+    options:
+      - 'JobPrivateAccess default'
+      - 'JobPrivateValues default'
+      - 'SubscriptionPrivateAccess default'
+    limits:
+      'Create-Job Print-Job Print-URI Validate-Job':
+        - 'Require user @OWNER @SYSTEM'
+        - 'Order deny,allow'
+```
+
 * `purge_unmanaged_queues`: Setting `true` will remove all queues from the node
   which do not match a `cups_queue` resource in the current catalog. Defaults to `false`.
 

--- a/README.md.erb
+++ b/README.md.erb
@@ -544,6 +544,46 @@ Installs, configures, and manages the CUPS service.
 
 * `papersize`: Sets the system's default `/etc/papersize`. See `man papersize` for supported values.
 
+* `policies`: Sets the printing policies (`default` and `authenticated`) for CUPS. By default,
+  it enables the default CUPS settings.  You can override those settings by setting all the options
+  you want set in a policy or setting all the directives in one of the limits under the policy.
+  You can, of course, also add more policies and other limits under the default policies as needed.
+
+```puppet
+  class { '::cups':
+    policies => {
+      'default' => {
+        'options' => [
+          'JobPrivateAccess default',
+          'JobPrivateValues default',
+          'SubscriptionPrivateAccess default',
+        ],
+        'limits' => {
+          'Create-Job Print-Job Print-URI Validate-Job' => [
+            'Require user @OWNER @SYSTEM',
+            'Order deny,allow',
+          ],
+        },
+      }
+    }
+  }
+```
+
+You can also do the same using hiera:
+
+```yaml
+cups::policies:
+  default:
+    options:
+      - 'JobPrivateAccess default'
+      - 'JobPrivateValues default'
+      - 'SubscriptionPrivateAccess default'
+    limits:
+      'Create-Job Print-Job Print-URI Validate-Job':
+        - 'Require user @OWNER @SYSTEM'
+        - 'Order deny,allow'
+```
+
 * `purge_unmanaged_queues`: Setting `true` will remove all queues from the node
   which do not match a `cups_queue` resource in the current catalog. Defaults to `false`.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@
 #   in order to run CUPS and provide `ipptool`. OS dependent defaults apply.
 # @param page_log_format Sets the `PageLogFormat` directive of the CUPS server.
 # @param papersize Sets the system's default `/etc/papersize`. See `man papersize` for supported values.
+# @param policies Sets the access policies for the CUPS server to use.
 # @param purge_unmanaged_queues Setting `true` will remove all queues from the node
 #   which do not match a `cups_queue` resource in the current catalog.
 # @param resources This attribute is intended for use with Hiera or any other ENC.
@@ -82,6 +83,7 @@ class cups (
   Variant[String, Array[String]]           $package_names          = $::cups::params::package_names,
   Optional[String]                         $page_log_format        = undef,
   Optional[String]                         $papersize              = undef,
+  Optional[Hash]                           $policies               = undef,
   Boolean                                  $purge_unmanaged_queues = false,
   Optional[Hash]                           $resources              = undef,
   Optional[Variant[String, Array[String]]] $server_alias           = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -293,6 +293,54 @@ RSpec.describe 'cups' do
       end
     end
 
+    describe 'policies' do
+      let(:facts) { any_supported_os }
+
+      describe 'by default' do
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: %r{<Policy default>\s*JobPrivateAccess default\s*JobPrivateValues default\s*SubscriptionPrivateAccess default\s*SubscriptionPrivateValues default\s*<Limit}) }
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: %r{<Policy authenticated>\s*JobPrivateAccess default\s*JobPrivateValues default\s*SubscriptionPrivateAccess default\s*SubscriptionPrivateValues default\s*<Limit}) }
+      end
+
+      context 'when policy options are overridden' do
+        let(:params) { {
+          'policies' => {
+            'default' => {
+              'options' => [
+                'JobPrivateAccess default',
+                'JobPrivateValues default',
+              ],
+            },
+            'authenticated' => {
+              'options' => [
+                'SubscriptionPrivateAccess default',
+                'SubscriptionPrivateValues default',
+              ],
+            }
+          }
+        } }
+
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: %r{<Policy default>\s*JobPrivateAccess default\s*JobPrivateValues default\s*<Limit}) }
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: %r{<Policy authenticated>\s*SubscriptionPrivateAccess default\s*SubscriptionPrivateValues default\s*<Limit}) }
+      end
+
+      context 'when policy options are overridden' do
+        let(:params) { {
+          'policies' => {
+            'default' => {
+              'limits' => {
+                'Create-Job Print-Job Print-URI Validate-Job' => [
+                  'Require user @OWNER @SYSTEM',
+                  'Order deny,allow'
+                ],
+              }
+            }
+          }
+        } }
+
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: %r{<Limit\s*Create-Job\s*Print-Job\s*Print-URI\s*Validate-Job>\s*Require\s*user\s*@OWNER\s*@SYSTEM\s*Order\s*deny,allow\s*</Limit>}) }
+      end
+    end
+
     describe 'log_debug_history' do
       let(:facts) { any_supported_os }
 

--- a/templates/cupsd/_policies.erb
+++ b/templates/cupsd/_policies.erb
@@ -1,63 +1,103 @@
-<Policy default>
-  JobPrivateAccess default
-  JobPrivateValues default
-  SubscriptionPrivateAccess default
-  SubscriptionPrivateValues default
-  <Limit Create-Job Print-Job Print-URI Validate-Job>
-    Order deny,allow
+<%
+cups_policies_defaults = {
+  'default' => {
+    'options' => [
+      'JobPrivateAccess default', 'JobPrivateValues default', 'SubscriptionPrivateAccess default', 'SubscriptionPrivateValues default',
+    ],
+    'limits' => {
+      'Create-Job Print-Job Print-URI Validate-Job' => ['Order deny,allow'],
+      'Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document' => [
+        'Require user @OWNER @SYSTEM',
+        'Order deny,allow',
+      ],
+      'CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices' => [
+        'AuthType Default',
+        'Require user @SYSTEM',
+        'Order deny,allow',
+      ],
+      'Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs' => [
+        'AuthType Default',
+        'Require user @SYSTEM',
+        'Order deny,allow',
+      ],
+      'Cancel-Job CUPS-Authenticate-Job' => [
+        'Require user @OWNER @SYSTEM',
+        'Order deny,allow',
+      ],
+      'All' => [
+        'Order deny,allow',
+      ],
+    },
+  },
+  'authenticated' => {
+    'options' => [
+      'JobPrivateAccess default', 'JobPrivateValues default', 'SubscriptionPrivateAccess default', 'SubscriptionPrivateValues default',
+    ],
+    'limits' => {
+      'Create-Job Print-Job Print-URI Validate-Job' => ['AuthType Default', 'Order deny,allow'],
+      'Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document' => [
+        'AuthType Default',
+        'Require user @OWNER @SYSTEM',
+        'Order deny,allow',
+      ],
+      'CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default' => [
+        'AuthType Default',
+        'Require user @SYSTEM',
+        'Order deny,allow',
+      ],
+      'Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs' => [
+        'AuthType Default',
+        'Require user @SYSTEM',
+        'Order deny,allow',
+      ],
+      'Cancel-Job CUPS-Authenticate-Job' => [
+        'AuthType Default',
+        'Require user @OWNER @SYSTEM',
+        'Order deny,allow',
+      ],
+      'All' => [
+        'Order deny,allow',
+      ],
+    },
+  },
+}
+
+@final_policies = cups_policies_defaults
+
+if ! @policies.nil? && @policies.is_a?(Hash)
+  @policies.each_pair do |policy, directives|
+    if ! @final_policies.has_key?(policy)
+      @final_policies[policy] ||= directives
+    else
+      if directives.has_key?('options')
+        @final_policies[policy]['options'] = directives['options']
+      end
+      if directives.has_key?('limits')
+        directives['limits'].each_pair do |lim, opts|
+          @final_policies[policy]['limits'][lim] = opts
+        end
+      end
+    end
+  end
+end
+
+-%>
+<% @final_policies.each_pair do |policy, directives| -%>
+<% next if directives.nil? || directives.empty? -%>
+<Policy <%= policy -%>>
+<% if directives.has_key?('options') -%>
+<% directives['options'].each do |opt| -%>
+  <%= opt %>
+<% end -%>
+<% end -%>
+<% if directives.has_key?('limits') -%>
+<% directives['limits'].each_pair do |lim, opts| -%>
+  <Limit <%= lim %>>
+<% opts.each do |opt| -%>
+    <%= opt %>
+<% end -%>
   </Limit>
-  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
-    Require user @OWNER @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices>
-    AuthType Default
-    Require user @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
-    AuthType Default
-    Require user @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit Cancel-Job CUPS-Authenticate-Job>
-    Require user @OWNER @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit All>
-    Order deny,allow
-  </Limit>
+<% end -%>
+<% end -%>
 </Policy>
-<Policy authenticated>
-  JobPrivateAccess default
-  JobPrivateValues default
-  SubscriptionPrivateAccess default
-  SubscriptionPrivateValues default
-  <Limit Create-Job Print-Job Print-URI Validate-Job>
-    AuthType Default
-    Order deny,allow
-  </Limit>
-  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
-    AuthType Default
-    Require user @OWNER @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default>
-    AuthType Default
-    Require user @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
-    AuthType Default
-    Require user @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit Cancel-Job CUPS-Authenticate-Job>
-    AuthType Default
-    Require user @OWNER @SYSTEM
-    Order deny,allow
-  </Limit>
-  <Limit All>
-    Order deny,allow
-  </Limit>
-</Policy>
+<% end -%>


### PR DESCRIPTION
This Pull Request adds the ability to customize polices (`<Policy>` sections in `cupsd.conf`).  With `$policies` not set, the configuration in `cupsd.conf` shouldn't change as the default is to use the exact same settings as before.  The way this is designed, you can create completely new policies as well as customize the options and limits in default policies.

I added to the README, added a `$policies` parameter to `init.pp`, added basic tests for the change, and rewrote the `_policies.erb` template.

Legal statement:

By committing to this project I transfer the full copyright for my contributions
to the current project maintainer as per the project's LICENSE file.
