### PR TITLE
Allow MaxJobsPerPrinter to be configured

### DIFF
--- a/README.md.erb
+++ b/README.md.erb
@@ -533,6 +533,8 @@ Installs, configures, and manages the CUPS service.
 
 * `max_request_size`: Specifies the maximum request/file size in bytes.
 
+* `max_jobs_per_printer`: Specifies the maximum jobs per printer.
+
 * `package_ensure`: Whether CUPS packages should be `present` or `absent`. Defaults to `present`.
 
 * `package_manage`: Whether to manage package installation at all. Defaults to `true`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,6 +77,7 @@ class cups (
   Optional[Integer]                        $max_clients_per_host   = undef,
   Optional[Variant[Integer, String]]       $max_log_size           = undef,
   Optional[Integer]                        $max_request_size       = undef,
+  Optional[Integer]                        $max_jobs_per_printer   = undef,
   String                                   $package_ensure         = 'present',
   Boolean                                  $package_manage         = true,
   Variant[String, Array[String]]           $package_names          = $::cups::params::package_names,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -397,6 +397,20 @@ RSpec.describe 'cups' do
       end
     end
 
+    describe 'max_jobs_per_printer' do
+      let(:facts) { any_supported_os }
+
+      context 'when not set' do
+        it { is_expected.to_not contain_file('/etc/cups/cupsd.conf').with(content: /^MaxJobsPerPrinter/) }
+      end
+
+      context 'when set to 100' do
+        let(:params) { { max_jobs_per_printer: 100 } }
+
+        it { is_expected.to contain_file('/etc/cups/cupsd.conf').with(content: /^MaxJobsPerPrinter 100$/) }
+      end
+    end
+
     describe 'package_manage' do
       context 'when set to true' do
         context 'with default package_names' do

--- a/templates/cupsd/_directives.erb
+++ b/templates/cupsd/_directives.erb
@@ -17,6 +17,7 @@ DefaultAuthType Basic
 <%= COMMENT_OUT if @max_clients_per_host.nil? -%>MaxClientsPerHost <%= @max_clients_per_host %>
 <%= COMMENT_OUT if @max_log_size.nil? -%>MaxLogSize <%= @max_log_size %>
 <%= COMMENT_OUT if @max_request_size.nil? -%>MaxRequestSize <%= @max_request_size %>
+<%= COMMENT_OUT if @max_jobs_per_printer.nil? -%>MaxJobsPerPrinter <%= @max_jobs_per_printer %>
 <%= COMMENT_OUT if @page_log_format.nil? -%>PageLogFormat "<%= @page_log_format %>"
 <%= COMMENT_OUT if @server_alias.nil? -%>ServerAlias <%= @server_alias.is_a?(Array) ? @server_alias.join(' ') : @server_alias %>
 <%= COMMENT_OUT if @server_name.nil? -%>ServerName <%= @server_name %>


### PR DESCRIPTION
Add MaxJobsPerPrinter as a configurable directive to in the template.
This is to be able to limit the jobs that can en enqueued for a
printer/class.

Pull Request template.

This Pull Request adds MaxJobsPerPrinter as a configurable directive.

I changed the _directives.rb template which seems to be where those directives are defined.

Related issue: 323

Legal statement:

By committing to this project I transfer the full copyright for my contributions
to the current project maintainer as per the project's LICENSE file.
